### PR TITLE
Allow additional context in request

### DIFF
--- a/src/Classes/Client.php
+++ b/src/Classes/Client.php
@@ -17,6 +17,7 @@ class Client extends Mutator {
         'Content-Type' => 'application/json',
         'User-Agent' => 'Laravel GraphQL client',
     ];
+    public Array $context = [];
 
     public function __construct(
         protected String|Null $endpoint
@@ -50,13 +51,13 @@ class Client extends Mutator {
      */
     public function getRequestAttribute()
     {
-        return stream_context_create([
+        return stream_context_create(array_merge([
             'http' => [
                 'method'  => 'POST',
                 'content' => json_encode(['query' => $this->raw_query, 'variables' => $this->variables]),
                 'header'  => $this->headers,
             ]
-        ]);
+        ], $this->context));
     }
 
 
@@ -116,6 +117,18 @@ class Client extends Mutator {
     }
 
 
+    /**
+     * Allow to append a new context info to the client
+     *
+     * @return Client
+     */
+    public function context(Array $context)
+    {
+        $this->context = $context;
+        return $this;
+    }
+
+    
     /**
      * Allow to pass multiple headers to the client
      *


### PR DESCRIPTION
I had a requirement to block ssl verification in development as I use a self signed certificate, so I needed to add additional context to get_file_contents.

These changes enable a request this like
```
$response = GraphQL::context([
            'ssl' => [
                "verify_peer"=>false,
                "verify_peer_name"=>false,
            ]
        ])->query('contentBlocks { id }')->get();
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
